### PR TITLE
Hide Rendering Options in Mac

### DIFF
--- a/source/options/OptionsState.hx
+++ b/source/options/OptionsState.hx
@@ -19,7 +19,7 @@ class OptionsState extends MusicBeatState
 		'Note Colors',
 		'Controls',
 		'Adjust Delay and Combo',
-		#if desktop 'Video Rendering', #end
+		#if (desktop && !mac) 'Video Rendering', #end
 		'Optimizations',
 		'Graphics',
 		'Visuals',


### PR DESCRIPTION
It doesn't work on Mac, so I think it's best to hide it.