### PR TITLE
Guard chart editor behind DISABLE_CHART_EDITOR flag

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -33,7 +33,7 @@ xsi:schemaLocation="http://lime.openfl.org/project/1.0.4 http://lime.openfl.org/
 		<!-- Adds the ability to use OpenFL asset lookup (defaults to sys if disabled)  -->
 		<define name="OPENFL_LOOKUP"/>
 
-		<!-- Adds the ability to use NativeFileSystem on the computer to acsess files -->
+		<!-- Adds the ability to use NativeFileSystem on the computer to access files -->
 		<define name="NATIVE_LOOKUP" if="MODS_ALLOWED" />
 	</section>
 

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -3762,6 +3762,7 @@ class PlayState extends MusicBeatState
 
 	public function openChartEditor()
 	{
+		#if !DISABLE_CHART_EDITOR
 		canResync = false;
 		FlxG.camera.followLerp = 0;
 		persistentUpdate = false;
@@ -3780,6 +3781,7 @@ class PlayState extends MusicBeatState
 
 		MusicBeatState.switchState(new ChartingState(!chartingMode));
 		chartingMode = true;
+		#end
 	}
 
 	function openCharacterEditor()
@@ -4412,11 +4414,13 @@ class PlayState extends MusicBeatState
 
 			playbackRate = 1;
 
+			#if !DISABLE_CHART_EDITOR
 			if (chartingMode)
 			{
 				openChartEditor();
 				return false;
 			}
+			#end
 
 			if (isStoryMode)
 			{

--- a/source/states/editors/MasterEditorMenu.hx
+++ b/source/states/editors/MasterEditorMenu.hx
@@ -13,7 +13,9 @@ import objects.Character;
 class MasterEditorMenu extends MusicBeatState
 {
 	var options:Array<String> = [
-		'Chart Editor', 
+		#if !DISABLE_CHART_EDITOR
+		'Chart Editor',
+		#end
 		'Character Editor', 
 		'Stage Editor', 
 		'Week Editor', 


### PR DESCRIPTION
Wrap Chart Editor functionality with conditional compilation (#if !DISABLE_CHART_EDITOR) so the editor can be excluded via the DISABLE_CHART_EDITOR define. Changes: PlayState now conditionally compiles openChartEditor calls and chartingMode check; MasterEditorMenu hides the 'Chart Editor' menu item when disabled. Also fix a small typo in Project.xml ('acsess' -> 'access'). This makes it possible to build without chart editor code when desired.

also related to #111 and because the define was already there but did nothing lol